### PR TITLE
prevented white overwrites

### DIFF
--- a/src/components/DesignBoard.js
+++ b/src/components/DesignBoard.js
@@ -6,14 +6,22 @@ class DesignBoard extends React.Component {
     board = ["1", "2", "3", "4"];
 
     render(){
-        const { handleAllowDrop, handleOnDrop, edit } = this.props;
+        const { handleOnDrag, handleAllowDrop, handleOnDrop, edit } = this.props;
         const { board } = this;
 
         return(
             <div className="flex-container flex-column">
                 <div className="flex-container flex-wrap" id="board">
                     {board.map(function(board, i){
-                        return(<DesignPad edit={edit} key={i} handleAllowDrop={handleAllowDrop} handleOnDrop={handleOnDrop}/>)
+                        return(
+                            <DesignPad 
+                                edit={edit} 
+                                key={i} 
+                                handleOnDrag={handleOnDrag} 
+                                handleAllowDrop={handleAllowDrop} 
+                                handleOnDrop={handleOnDrop}
+                            />
+                        )
                     })}
                 </div>
             </div>

--- a/src/components/DesignContainer.js
+++ b/src/components/DesignContainer.js
@@ -51,7 +51,14 @@ class DesignContainer extends React.Component {
                 </div>
                 <div className="mainContainer">
                     <div className="mainContainer--left"><PadInput edit={edit} handleOnDrag={handleOnDrag} /></div>
-                    <div className="mainContainer--center"><DesignBoard edit={edit} handleAllowDrop={handleAllowDrop} handleOnDrop={handleOnDrop} /></div>
+                    <div className="mainContainer--center">
+                        <DesignBoard 
+                            edit={edit} 
+                            handleOnDrag={handleOnDrag}
+                            handleAllowDrop={handleAllowDrop} 
+                            handleOnDrop={handleOnDrop} 
+                        />
+                    </div>
                     <div className="mainContainer--right"></div>
                 </div>
                 <div className="bottomContainer">

--- a/src/components/DesignPad.js
+++ b/src/components/DesignPad.js
@@ -3,11 +3,12 @@ import "../css/DesignPad.css"
 
 class DesignPad extends React.Component {
     render(){
-        const { handleAllowDrop, handleOnDrop, edit } = this.props;
+        const { handleOnDrag, handleAllowDrop, handleOnDrop, edit } = this.props;
 
         return(
             <div
                 className= "designPad"
+                onDragStart={handleOnDrag}
                 onDragOver={handleAllowDrop}
                 onDrop={handleOnDrop}
                 draggable={edit}


### PR DESCRIPTION
When DesignPad was dragged, it was overwriting other Pad with a default case of white background.
Prevented that background overwrite.